### PR TITLE
Add Python 3.5 and 3.6 to the supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   - TOX_ENV=py32
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py35
+  - TOX_ENV=py36
   - TOX_ENV=pypy
 install:
   - git config --global user.email "bumpversion-test-git@travis.ci"

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py27-configparser, pypy
+envlist = py27, py33, py34, py35, py36, py27-configparser, pypy
 
 [testenv]
 passenv = HOME


### PR DESCRIPTION
@c4urself [PR#8](https://github.com/c4urself/bump2version/pull/8) from @ekoh: Add Python 3.5 and 3.6 to the supported versions