### PR TITLE
Explicitly parse 'independent' config as boolean

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -686,6 +686,9 @@ def main(original_args=None):
                     section_config['values'] = list(filter(None, (x.strip() for x in section_config['values'].splitlines())))
                     this_version_part_configuration = ConfiguredVersionPartConfiguration
 
+                if config.has_option(section_name, 'independent'):
+                    section_config['independent'] = config.getboolean(section_name, 'independent')
+
                 part_configs[section_value] = this_version_part_configuration(**section_config)
 
             elif section_prefix == "file":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2487,3 +2487,25 @@ def test_example_13(tmpdir, capsys):
         #define BUILD_DESCRIPTION 2.2.0 (XXXX 12:00)
         """).replace("XXXX", "{:04}-{:02}-{:02}".format(now.year, now.month, now.day)) \
            == tmpdir.join("VERSION.h").read()
+
+
+def test_independent_falsy_value_in_config_does_not_bump_independently(tmpdir, capsys):
+    tmpdir.join("VERSION").write("2.1.0-5123")
+    tmpdir.chdir()
+    tmpdir.join(".bumpversion.cfg").write(dedent("""
+        [bumpversion]
+        current_version: 2.1.0-5123
+        parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-(?P<build>\d+)
+        serialize = {major}.{minor}.{patch}-{build}
+
+        [bumpversion:file:VERSION]
+
+        [bumpversion:part:build]
+        independent = 0
+        """))
+
+    main(['build'])
+    assert '2.1.0-5124' == tmpdir.join("VERSION").read()
+
+    main(['major'])
+    assert '3.0.0-0' == tmpdir.join("VERSION").read()


### PR DESCRIPTION
Heya!

This PR fixes an issue where the 'independent' config is
parsed and evaluated as a string. This causes counter-intuitive
behaviour when supplying a falsy value to the configuration, such as

    independent = 0

This would previously be parsed as a string, and since '0' is a truthy
value, the independent behaviour would be enabled.

The issue is fixed by parsing the configuration explicitly as a boolean. 

I also added a test which demonstrates the behaviour. I've run (with success) the entire test suite for Python2.7 and 3.6 locally.